### PR TITLE
Update draft-ietf-opsawg-discardmodel-04.yang.txt

### DIFF
--- a/draft-ietf-opsawg-discardmodel/yang/draft-ietf-opsawg-discardmodel-04.yang.txt
+++ b/draft-ietf-opsawg-discardmodel/yang/draft-ietf-opsawg-discardmodel-04.yang.txt
@@ -332,12 +332,12 @@ module ietf-packet-discard-reporting {
         description
           "The number of invalid packets discarded due to other reasons.";
       }
-      leaf ttl-expired {
-        type uint32;
-        description
-          "The number of received packets discarded due to expired
-           TTL.";
-      }
+    }
+    leaf ttl-expired {
+      type uint32;
+      description
+        "The number of received packets discarded due to expired
+         TTL.";
     }
     leaf no-route {
       type uint32;


### PR DESCRIPTION
move TTL discards 1 level up the tree, out from under l3 errors